### PR TITLE
server: sort tracks by trying to convert the trackid to int

### DIFF
--- a/server/toniecloud/client.py
+++ b/server/toniecloud/client.py
@@ -54,7 +54,7 @@ class TonieCloud:
         data = {
             "chapters": [
                 {"title": track.title, "file": self._upload_track(track)}
-                for track in sorted(audiobook.tracks, key=lambda t: t.track)
+                for track in sorted(audiobook.tracks, key=lambda t: int(t.track) if t.track.isdigit() else t.track )
             ]
         }
 


### PR DESCRIPTION
# Motivation
Sometimes it happens that the track list is parsed as string instead of integer which results in weirdly sorted album uploads :

- upload chapter 1
- upload chapter 11
- upload chapter 12
- upload chapter 2
- upload chapter 3

The PR adds an extra sorting step which tries to parse the text fields as integer