### PR TITLE
docker-compose: use dockerfiles instead of building on startup

### DIFF
--- a/Dockerfile-back
+++ b/Dockerfile-back
@@ -1,0 +1,6 @@
+FROM python:3.8-buster
+COPY ./server /backend
+WORKDIR /backend
+RUN pip install -r requirements.txt
+RUN mkdir -p /backend/assets/covers /backend/assets/audiobooks
+CMD python app.py

--- a/Dockerfile-front
+++ b/Dockerfile-front
@@ -1,0 +1,6 @@
+FROM node:14.7-stretch
+COPY ./client /frontend
+WORKDIR /frontend
+RUN npm install
+RUN mkdir -p /frontend/public/assets/covers
+CMD npm run serve

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,39 +2,33 @@
 version: '3'
 services:
   frontend:
-    image: node:14.7-stretch
+    build:
+      context: .
+      dockerfile: Dockerfile-front
     environment:
       - VUE_APP_BACKEND_SCHEME=${TONIE_AUDIO_MATCH_BACKEND_SCHEME}
       - VUE_APP_BACKEND_HOST=${TONIE_AUDIO_MATCH_BACKEND_HOST}
       - VUE_APP_BACKEND_PORT=${TONIE_AUDIO_MATCH_BACKEND_PORT}
-    command: >
-      bash -c "cd /frontend &&
-      npm install &&
-      npm run serve"
     networks:
       - toniebox
     ports:
       - ${TONIE_AUDIO_MATCH_FRONTEND_PORT}:8080
     volumes:
-      - ./client/:/frontend
       - ./albumart/:/frontend/public/assets/covers
 
   backend:
-    image: python:3.8-buster
+    build:
+      context: .
+      dockerfile: Dockerfile-back
     environment:
       - TONIE_AUDIO_MATCH_MEDIA_PATH
       - TONIE_AUDIO_MATCH_USER
       - TONIE_AUDIO_MATCH_PASS
-    command: >
-      bash -c "cd /backend &&
-      pip install -r requirements.txt &&
-      python app.py"
     networks:
       - toniebox
     ports:
       - ${TONIE_AUDIO_MATCH_BACKEND_PORT}:5000
     volumes:
-      - ./server/:/backend
       - ./albumart/:/backend/assets/covers
       - ${TONIE_AUDIO_MATCH_MEDIA_PATH}:/backend/assets/audiobooks
 


### PR DESCRIPTION
# Motivation
right now the docker containers are configured to build at first startup.
The PR tries to separate build from run phase by adding a dockerfile for each container which fetches the respective dependencies beforehand.
With this it is possible to start the container as a user other than root and make the file-system read-only